### PR TITLE
Update action.yml to use actions running on Node 20 instead of Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,11 +32,11 @@ runs:
     using: "composite"
     steps:
         - name: Checkout repo
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
           with:
             path: repo
         - name: Install Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v5
           with:
             python-version: '3.x'
         - name: Install dependencies


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/