### PR TITLE
Add the option to submit for review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,12 @@ The script will upload everything from **the helper `repo` folder** to the `DATA
 python dataverse.py 9s3-7d46-hd https://demo.dataverse.org/ doi:10.70122/FK2/LVUADQ user/my-repo -p TRUE
 ```
 
+- To upload files and submit the data record for review:
+
+```
+python dataverse.py 9s3-7d46-hd https://demo.dataverse.org/ doi:10.70122/FK2/LVUADQ user/my-repo -p FALSE -rev TRUE
+```
+
 - To upload files from a single folder, use:
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To use this action, you will need the following input parameters:
 | `GITHUB_DIR` | No | Use `GITHUB_DIR` if you would like to upload files from only one or more subdirectories in your GitHub repository (i.e., `data/`, `plots/`).                                                                                                                                                                                                                                                                                                                                           |
 | `DELETE` | No | Can be `True` or `False` (by default `True`) depending on whether all files should be deleted in the dataset on Dataverse before upload.                                                                                                                                                                                                                                                                                                                                       |
 | `PUBLISH` | No | Can be `True` or `False` (by default `False`) depending on whether you'd like to automatically create a new version of the dataset upon upload. If `False`, the uploaded dataset will be a `DRAFT`.                                                                                                                                                                                                                                                                            |
+| `REVIEW` | No | Can be `True` or `False` (by default `False`) depending on whether you'd like to automatically submit the dataset for review upon upload. If `True`, the uploaded dataset will be a `In Review`.                                                                                                                                                                                                                                                                            |
 
 ## Usage
 
@@ -107,6 +108,22 @@ steps:
       GITHUB_DIR: data
       DELETE: False
       PUBLISH: True
+```
+
+If you would like the action to submit the dataset for review instead:
+
+```
+steps:
+  - name: Send repo to Dataverse 
+    uses: IQSS/dataverse-uploader@v1.6
+    with:
+      DATAVERSE_TOKEN: ${{secrets.DATAVERSE_TOKEN}}
+      DATAVERSE_SERVER: https://demo.dataverse.org
+      DATAVERSE_DATASET_DOI: doi:10.70122/FK2/LVUA
+      GITHUB_DIR: data
+      DELETE: False
+      PUBLISH: False
+      REVIEW: True
 ```
 
 ## Q&A

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
       required: false
       description: "publish after upload"
       default: 'false'
+    REVIEW:
+      required: false
+      description: "submit for review after upload"
+      default: 'false'
 
 runs:
     using: "composite"
@@ -56,3 +60,4 @@ runs:
             -d "${{inputs.GITHUB_DIR}}" 
             -r "${{inputs.DELETE}}" 
             -p "${{inputs.PUBLISH}}" 
+            -rev "${{inputs.REVIEW}}"

--- a/dataverse.py
+++ b/dataverse.py
@@ -26,6 +26,11 @@ def parse_arguments():
         "-p", "--publish", help="Publish a new dataset version after upload.", \
         choices=('True', 'TRUE', 'true', 'False', 'FALSE', 'false'), \
         default='false')
+    parser.add_argument(
+        "-rev", "--review", help="Submit the dataset for review after upload.",
+        choices=("True", "TRUE", "true", "False", "FALSE", "false"),
+        default="false",
+    )
 
     args_ = parser.parse_args()
     return args_
@@ -102,3 +107,16 @@ if __name__ == '__main__':
     if args.publish.lower() == 'true':
         # publish updated dataset
         resp = api.publish_dataset(args.doi, release_type="major")
+
+    if args.review.lower() == "true":
+        headers = {
+            "X-Dataverse-key": token,
+        }
+        payload = {
+            "persistentId": args.doi,
+        }
+        response = requests.post(
+            dataverse_server + "/api/datasets/:persistentId/submitForReview",
+            payload=params,
+            headers=headers,
+        )

--- a/dataverse.py
+++ b/dataverse.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
                 delete_api + str(fileid), \
                 auth = (token  , ""))
 
-    # check if there is a list of dirs to upload 
+    # check if there is a list of dirs to upload
     paths = ['repo']
     if args.dir:
         dirs = args.dir.strip().replace(",", " ")
@@ -117,6 +117,6 @@ if __name__ == '__main__':
         }
         response = requests.post(
             dataverse_server + "/api/datasets/:persistentId/submitForReview",
-            payload=params,
+            params=payload,
             headers=headers,
         )


### PR DESCRIPTION
Hi, dataverse-uploader maintainers👋. To address issue #17, I gave a shot at implementing an option to submit the dataset for review. I added a new optional argument called `REVIEW`. When set to `TRUE`, the action automatically submits the dataset for review upon upload. I think it makes sense to keep this option separate from the `PUBLISH` one, but let me know what you think. I can always adjust things to have a single argument if you prefer.

I also thought it would be desirable to prevent any attempt to change the content by the action if the dataset is being reviewed. So, I added a check to stop the action if the targeted dataset is already under review.